### PR TITLE
Rename app from yet-claude-code to yac

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-`yet-claude-code` is an alternative implementation of Claude Code that provides model flexibility. While Claude Code only works with Claude models, this project aims to deliver the same core features but with the ability to switch between different AI models (e.g., GPT-4, Gemini, local models, etc.).
+`yac` (Yet Another Claude) is an alternative implementation of Claude Code that provides model flexibility. While Claude Code only works with Claude models, this project aims to deliver the same core features but with the ability to switch between different AI models (e.g., GPT-4, Gemini, local models, etc.).
 
 The project uses modern Python packaging standards with `pyproject.toml` configuration.
 
@@ -17,7 +17,7 @@ The project uses modern Python packaging standards with `pyproject.toml` configu
 ## Project Structure
 
 ```
-src/yet_claude_code/   # Main package directory
+src/yac/             # Main package directory
 ├── __init__.py       # Package initialization
 ├── main.py          # Main entry point
 ├── cli/             # Command-line interface
@@ -128,7 +128,7 @@ The project supports standard development workflows:
 1. **Dependencies**: Managed via `pyproject.toml` with automatic MCP server installation
 2. **Testing**: Run test suite with `python -m pytest tests/`
 3. **Linting**: Code quality checks via pre-commit hooks
-4. **Development**: CLI entry point at `src/yet_claude_code/cli/app.py`
+4. **Development**: CLI entry point at `src/yac/cli/app.py`
 
 ## Claude Code Feature Parity
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
-name = "yet-claude-code"
+name = "yac"
 version = "0.1.0"
-description = "Multi-model AI assistant with MCP integration"
+description = "YAC (Yet Another Claude) - Multi-model AI assistant with MCP integration"
 readme = "CLAUDE.md"
 requires-python = ">=3.12"
 dependencies = [
@@ -26,8 +26,7 @@ dev = [
 ]
 
 [project.scripts]
-ycc = "yet_claude_code.cli.app:main"
-yet-claude-code = "yet_claude_code.cli.app:main"
+yac = "yac.cli.app:main"
 
 [dependency-groups]
 dev = [

--- a/src/yac/__init__.py
+++ b/src/yac/__init__.py
@@ -1,0 +1,3 @@
+"""YAC (Yet Another Claude) - Multi-model AI assistant with MCP integration."""
+
+__version__ = "0.1.0"

--- a/src/yac/__main__.py
+++ b/src/yac/__main__.py
@@ -1,0 +1,4 @@
+from .cli.app import main
+
+if __name__ == "__main__":
+    main()

--- a/src/yac/cli/__init__.py
+++ b/src/yac/cli/__init__.py
@@ -1,0 +1,1 @@
+"""CLI module for YAC."""

--- a/src/yac/cli/app.py
+++ b/src/yac/cli/app.py
@@ -1,0 +1,554 @@
+import asyncio
+import sys
+from typing import Optional
+
+# Use the newer memory approach instead of deprecated ConversationBufferMemory
+from langchain_core.messages import HumanMessage, ToolMessage
+from pydantic import SecretStr
+from .config import Config
+from .display import Display
+from .error_handlers import GracefulErrorMixin
+from ..mcp.client import MCPClient
+from ..mcp.config import MCPServerConfig, MCPTransport
+from ..mcp.defaults import get_default_mcp_servers, get_optional_mcp_servers
+from ..mcp.langchain_bridge import MCPLangChainBridge
+
+
+class YACApp(GracefulErrorMixin):
+    def __init__(self, provider: Optional[str] = None, model: Optional[str] = None):
+        super().__init__()  # Initialize GracefulErrorMixin
+        self.config = Config()
+        self.display = Display()
+        self.messages: list = []  # Store conversation history directly
+        self.base_llm = self._create_llm(provider, model)
+        self.llm = self.base_llm  # Will be updated with tools after MCP setup
+        self.mcp_client = MCPClient()
+        self.bridge = MCPLangChainBridge(self.mcp_client)
+        self.running = True
+
+    def _create_llm(self, provider: Optional[str] = None, model: Optional[str] = None):
+        provider_name = provider or self.config.get_provider()
+        model_name = model or self.config.get_model()
+        api_key = self.config.get_api_key(provider_name)
+
+        if not api_key:
+            raise ValueError(f"No API key found for {provider_name}")
+
+        if provider_name == "openai":
+            from langchain_openai import ChatOpenAI
+
+            return ChatOpenAI(
+                model=model_name,
+                api_key=SecretStr(api_key),
+                streaming=self.config.should_stream(),
+            )
+        elif provider_name == "anthropic":
+            from langchain_anthropic import ChatAnthropic
+
+            return ChatAnthropic(
+                model_name=model_name,
+                api_key=SecretStr(api_key),
+                streaming=self.config.should_stream(),
+                timeout=None,
+                stop=None,
+            )
+        elif provider_name == "google":
+            from langchain_google_genai import ChatGoogleGenerativeAI
+
+            return ChatGoogleGenerativeAI(
+                model=model_name,
+                google_api_key=api_key,
+                streaming=self.config.should_stream(),
+            )
+        else:
+            raise ValueError(f"Unsupported provider: {provider_name}")
+
+    async def run(self):
+        self.display.welcome()
+        await self._load_mcp_servers()
+
+        while self.running:
+            try:
+                user_input = input(self.display.get_prompt())
+                if not user_input.strip():
+                    continue
+                if user_input.lower() in ["/exit", "/quit", "/q"]:
+                    break
+                if user_input.startswith("/"):
+                    await self.handle_command(user_input)
+                    continue
+                await self.process_message(user_input)
+            except (KeyboardInterrupt, EOFError):
+                break
+            except Exception as e:
+                self.display.error(str(e))
+
+        self.display.goodbye()
+
+    async def process_message(self, content: str):
+        try:
+            # Store user message first
+            self.messages.append(HumanMessage(content=content))
+
+            # Add system context to help the AI reason through problems
+            await self._add_reasoning_context(content)
+
+            # Show thinking indicator
+            self.display.show_loading("🤔 Thinking...")
+
+            # Start agent-style conversation loop
+            while True:
+                # Get response from LLM with reasoning instructions
+                response = await self.llm.ainvoke(self.messages)
+
+                # Clear loading indicator
+                self.display.clear_loading()
+
+                # Store the AI response
+                self.messages.append(response)
+
+                # Handle tool calls if present
+                if hasattr(response, "tool_calls") and response.tool_calls:
+                    # Execute each tool call and collect results
+                    tool_messages = []
+
+                    for tool_call in response.tool_calls:
+                        try:
+                            # Find the tool by name
+                            tools = await self.bridge.get_langchain_tools()
+                            tool = next(
+                                (t for t in tools if t.name == tool_call["name"]), None
+                            )
+
+                            if tool:
+                                # Show tool execution indicator
+                                self.display.show_loading(
+                                    f"🔧 Executing {tool_call['name']}..."
+                                )
+
+                                # Execute the tool
+                                tool_result = await tool.ainvoke(tool_call["args"])
+
+                                # Clear loading and show result
+                                self.display.clear_loading()
+
+                                # Create tool message
+                                tool_message = ToolMessage(
+                                    content=str(tool_result),
+                                    tool_call_id=tool_call["id"],
+                                )
+                                tool_messages.append(tool_message)
+
+                                self.display.print(
+                                    f"🔧 Executed {tool_call['name']}: {tool_result}"
+                                )
+                            else:
+                                error_msg = f"Tool '{tool_call['name']}' not found"
+                                tool_message = ToolMessage(
+                                    content=error_msg, tool_call_id=tool_call["id"]
+                                )
+                                tool_messages.append(tool_message)
+                                self.display.error(error_msg)
+
+                        except Exception as e:
+                            # Use graceful error handling with strategy pattern
+                            error_context = await self.handle_tool_error_gracefully(
+                                e, tool_call["name"], tool_call["args"], tools
+                            )
+
+                            # Create tool message with helpful context
+                            tool_message = ToolMessage(
+                                content=error_context, tool_call_id=tool_call["id"]
+                            )
+                            tool_messages.append(tool_message)
+                            self.display.print(f"🛠️  Error handled: {error_context}")
+
+                    # Add all tool messages to conversation
+                    self.messages.extend(tool_messages)
+
+                    # Show processing indicator for next iteration
+                    self.display.show_loading("🧠 Processing results...")
+                    # Continue the loop to get LLM's final response
+                    continue
+                else:
+                    # No tool calls, print response and exit loop
+                    self.display.print_response(response.content)
+                    break
+
+        except Exception as e:
+            self.display.error(f"Error: {e}")
+
+    async def _handle_tool_error(self, tool_call, error, tools):
+        """Intelligent error handling for tool failures."""
+        tool_name = tool_call["name"]
+        args = tool_call["args"]
+        error_str = str(error).lower()
+
+        try:
+            # Handle file not found errors
+            if (
+                "file not found" in error_str
+                or "no such file" in error_str
+                or "does not exist" in error_str
+            ):
+                return await self._handle_file_not_found(tool_name, args, tools)
+
+            # Handle permission errors
+            elif "permission denied" in error_str:
+                return await self._handle_permission_error(tool_name, args, tools)
+
+            # Handle directory not found
+            elif "directory not found" in error_str or "no such directory" in error_str:
+                return await self._handle_directory_not_found(tool_name, args, tools)
+
+            # Handle network/connection errors
+            elif (
+                "connection" in error_str
+                or "timeout" in error_str
+                or "network" in error_str
+            ):
+                return await self._handle_network_error(tool_name, args, tools)
+
+        except Exception as retry_error:
+            self.display.print(f"🔄 Intelligent retry also failed: {retry_error}")
+
+        return None
+
+    async def _handle_file_not_found(self, tool_name, args, tools):
+        """Handle file not found errors by providing context for AI reasoning."""
+        # Extract filename from args
+        filename = None
+        if isinstance(args, dict):
+            filename = args.get("path") or args.get("file_path") or args.get("filename")
+        elif isinstance(args, str):
+            filename = args
+
+        if not filename:
+            return None
+
+        # Instead of hardcoded search, provide information for the AI to reason about
+        error_context = f"File '{filename}' not found. "
+
+        # Give the AI information about available tools to investigate
+        available_tools = [t.name for t in tools]
+        investigation_tools = [
+            t
+            for t in available_tools
+            if t
+            in ["search_files", "list_directory", "directory_tree", "execute_command"]
+        ]
+
+        if investigation_tools:
+            error_context += (
+                f"Available tools to investigate: {', '.join(investigation_tools)}. "
+            )
+            error_context += "Consider using search_files to look for similar files, list_directory to see what's available, or execute_command with 'find' to search the filesystem."
+
+        return error_context
+
+    async def _handle_permission_error(self, tool_name, args, tools):
+        """Handle permission errors."""
+        self.display.print("🔒 Permission denied, trying alternative approaches...")
+        # Could implement chmod, sudo alternatives, or different file operations
+        return None
+
+    async def _handle_directory_not_found(self, tool_name, args, tools):
+        """Handle directory not found errors."""
+        directory = None
+        if isinstance(args, dict):
+            directory = args.get("path") or args.get("directory")
+        elif isinstance(args, str):
+            directory = args
+
+        if directory:
+            self.display.print(
+                f"📁 Directory '{directory}' not found, checking parent directories..."
+            )
+            # Could implement directory creation or alternative path suggestions
+
+        return None
+
+    async def _handle_network_error(self, tool_name, args, tools):
+        """Handle network/connection errors with retry logic."""
+        self.display.print("🌐 Network error detected, retrying...")
+
+        # Simple retry for network operations
+        try:
+            import asyncio
+
+            await asyncio.sleep(1)  # Brief delay
+
+            original_tool = next((t for t in tools if t.name == tool_name), None)
+            if original_tool:
+                retry_result = await original_tool.ainvoke(args)
+                self.display.print("✅ Network retry successful")
+                return retry_result
+
+        except Exception as retry_error:
+            self.display.print(f"🌐 Network retry failed: {retry_error}")
+
+        return None
+
+    async def _add_reasoning_context(self, content: str):
+        """Add context to help the AI reason through problems step by step."""
+        from langchain_core.messages import SystemMessage
+
+        reasoning_prompt = """You are a coding assistant that solves problems step by step, like Claude Code.
+
+When faced with a problem:
+1. THINK about what you need to do first
+2. Use the available tools to investigate (search_files, list_directory, read_file, etc.)
+3. Based on what you find, decide the next step
+4. Take action using the appropriate tools
+5. Continue until the problem is solved
+
+If a file is missing:
+- Use search_files to look for similar files
+- Use list_directory to see what's available
+- Try different search terms and patterns
+- Don't give up after the first attempt - keep investigating
+
+Available tools include: read_file, write_file, search_files, list_directory, directory_tree, execute_command, git_status, and more.
+
+Be methodical and persistent. Reason through each step aloud."""
+
+        # Only add this context once per conversation to avoid repetition
+        if not any(
+            isinstance(msg, SystemMessage) and "step by step" in msg.content
+            for msg in self.messages
+        ):
+            self.messages.append(SystemMessage(content=reasoning_prompt))
+
+    async def _load_mcp_servers(self):
+        self.display.print("Starting MCP setup...")
+        servers = self.config.get_mcp_servers()
+
+        # If no servers configured, set up defaults
+        if not servers:
+            self.display.print("Setting up default MCP servers...")
+            default_servers = get_default_mcp_servers()
+            for server in default_servers.values():
+                self.config.add_mcp_server(server)
+            servers = default_servers
+
+        # Connect to servers with timeout and error handling
+        for server in servers.values():
+            try:
+                # Show loading indicator for server connection
+                self.display.show_loading(f"Connecting to {server.name}...")
+
+                # Add timeout to prevent hanging
+                success = await asyncio.wait_for(
+                    self.mcp_client.add_server(server), timeout=30.0
+                )
+
+                # Clear loading indicator
+                self.display.clear_loading()
+
+                if success:
+                    self.display.print(f"✓ Connected to MCP server: {server.name}")
+                else:
+                    self.display.print(
+                        f"✗ Failed to connect to MCP server: {server.name}"
+                    )
+            except asyncio.TimeoutError:
+                # Clear loading indicator on timeout
+                self.display.clear_loading()
+                self.display.print(f"✗ Timeout connecting to MCP server: {server.name}")
+            except Exception as e:
+                # Clear loading indicator on error
+                self.display.clear_loading()
+                self.display.print(
+                    f"✗ Error connecting to MCP server {server.name}: {e}"
+                )
+
+        connected_servers = len(self.mcp_client.sessions)
+        if connected_servers > 0:
+            self.display.print(
+                f"MCP setup complete - {connected_servers} server(s) connected"
+            )
+            # Bind MCP tools to the LLM
+            try:
+                self.llm = await self.bridge.bind_tools_to_llm(self.base_llm)
+                self.display.print("✓ MCP tools bound to LLM")
+            except Exception as e:
+                self.display.print(f"Warning: Failed to bind MCP tools: {e}")
+                self.llm = self.base_llm
+        else:
+            self.display.print(
+                "MCP setup complete - no servers connected (chat still works!)"
+            )
+
+    async def handle_command(self, command: str):
+        parts = command.split()
+        cmd = parts[0]
+
+        if cmd == "/help":
+            self.display.show_help()
+        elif cmd == "/clear":
+            self.messages.clear()
+            self.display.print("Conversation cleared.")
+        elif cmd == "/mcp":
+            await self._handle_mcp_command(parts[1:])
+        else:
+            self.display.print(f"Unknown command: {command}")
+
+    async def _handle_mcp_command(self, args):
+        if not args:
+            self.display.print("Usage: /mcp <add|remove|list|tools|available>")
+            return
+
+        subcmd = args[0]
+
+        if subcmd == "add":
+            if len(args) < 3:
+                self.display.print("Usage: /mcp add <name> <transport> [options...]")
+                return
+            await self._add_mcp_server(args[1:])
+        elif subcmd == "remove":
+            if len(args) < 2:
+                self.display.print("Usage: /mcp remove <name>")
+                return
+            await self._remove_mcp_server(args[1])
+        elif subcmd == "list":
+            await self._list_mcp_servers()
+        elif subcmd == "tools":
+            server_name = args[1] if len(args) > 1 else None
+            await self._list_mcp_tools(server_name)
+        elif subcmd == "available":
+            await self._list_available_mcp_servers()
+        else:
+            self.display.print(f"Unknown MCP command: {subcmd}")
+
+    async def _add_mcp_server(self, args):
+        try:
+            name = args[0]
+            transport = MCPTransport(args[1])
+
+            if transport == MCPTransport.STDIO:
+                if len(args) < 3:
+                    self.display.print("STDIO transport requires command")
+                    return
+                command = args[2:]
+                config = MCPServerConfig(
+                    name=name, transport=transport, command=command
+                )
+            else:
+                if len(args) < 3:
+                    self.display.print(f"{transport.value} transport requires URL")
+                    return
+                url = args[2]
+                config = MCPServerConfig(name=name, transport=transport, url=url)
+
+            success = await self.mcp_client.add_server(config)
+            if success:
+                self.config.add_mcp_server(config)
+                self.display.print(f"Added MCP server: {name}")
+            else:
+                self.display.print(f"Failed to add MCP server: {name}")
+        except Exception as e:
+            self.display.print(f"Error adding MCP server: {e}")
+
+    async def _remove_mcp_server(self, name: str):
+        success = await self.mcp_client.remove_server(name)
+        if success:
+            self.config.remove_mcp_server(name)
+            self.display.print(f"Removed MCP server: {name}")
+        else:
+            self.display.print(f"MCP server not found: {name}")
+
+    async def _list_mcp_servers(self):
+        servers = self.config.list_mcp_servers()
+        if servers:
+            self.display.print("MCP Servers:")
+            for server in servers:
+                self.display.print(f"  - {server}")
+        else:
+            self.display.print("No MCP servers configured")
+
+    async def _list_mcp_tools(self, server_name: Optional[str]):
+        tools = await self.mcp_client.list_tools(server_name)
+        if tools:
+            for server, server_tools in tools.items():
+                self.display.print(f"Tools from {server}:")
+                for tool in server_tools:
+                    self.display.print(
+                        f"  - {tool['name']}: {tool.get('description', 'No description')}"
+                    )
+        else:
+            self.display.print("No tools available")
+
+    async def _list_available_mcp_servers(self):
+        """List all available MCP servers (default + optional)."""
+        import os
+
+        self.display.print("Available MCP Servers:")
+        self.display.print("")
+
+        # Show default servers (always available)
+        default_servers = get_default_mcp_servers()
+        self.display.print("Default servers (always available):")
+        for name, config in default_servers.items():
+            status = (
+                "✓ Connected" if name in self.mcp_client.sessions else "○ Available"
+            )
+            self.display.print(f"  {status} {name}")
+            self.display.print(f"    Command: {' '.join(config.command)}")
+
+        self.display.print("")
+
+        # Show optional servers
+        optional_servers = get_optional_mcp_servers()
+        self.display.print("Optional servers (require setup/API keys):")
+        for name, config in optional_servers.items():
+            # Check if server would be enabled (has required env vars)
+            enabled = True
+            required_env_vars = []
+
+            if name == "github" and not os.getenv("GITHUB_TOKEN"):
+                enabled = False
+                required_env_vars.append("GITHUB_TOKEN")
+            elif name == "brave-search" and not os.getenv("BRAVE_API_KEY"):
+                enabled = False
+                required_env_vars.append("BRAVE_API_KEY")
+            elif name == "slack" and not os.getenv("SLACK_BOT_TOKEN"):
+                enabled = False
+                required_env_vars.append("SLACK_BOT_TOKEN")
+
+            if enabled:
+                status = (
+                    "✓ Connected" if name in self.mcp_client.sessions else "✓ Available"
+                )
+            else:
+                status = f"✗ Missing: {', '.join(required_env_vars)}"
+
+            self.display.print(f"  {status} {name}")
+            self.display.print(f"    Command: {' '.join(config.command)}")
+
+        self.display.print("")
+        self.display.print(
+            "To enable optional servers, set the required environment variables."
+        )
+        self.display.print(
+            "Use '/mcp add <name> stdio <command>' to add custom servers."
+        )
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="YAC - Yet Another Claude (Multi-model AI assistant)"
+    )
+    parser.add_argument("--provider", help="AI provider (openai, anthropic, google)")
+    parser.add_argument("--model", help="Model to use")
+    args = parser.parse_args()
+
+    try:
+        app = YACApp(provider=args.provider, model=args.model)
+        asyncio.run(app.run())
+    except KeyboardInterrupt:
+        sys.exit(0)
+    except Exception as e:
+        print(f"Error: {e}")
+        sys.exit(1)

--- a/src/yac/cli/config.py
+++ b/src/yac/cli/config.py
@@ -1,0 +1,154 @@
+import os
+import json
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from ..mcp.config import MCPServerConfig, MCPTransport
+from .validators import ConfigValidator, ValidationReporter
+
+
+class Config:
+    def __init__(self):
+        self.config_dir = Path.home() / ".yac"
+        self.config_file = self.config_dir / "config.json"
+        self.config_dir.mkdir(exist_ok=True)
+        self._config_data = self._load_config()
+        self.validator = ConfigValidator()
+        self.reporter = ValidationReporter()
+
+    def get_provider(self) -> str:
+        return os.getenv("YAC_PROVIDER", "openai")
+
+    def get_model(self) -> str:
+        provider = self.get_provider()
+        defaults = {
+            "openai": "o3-mini",
+            "anthropic": "claude-3-sonnet-20240229",
+            "google": "gemini-pro",
+        }
+        return os.getenv("YAC_MODEL", defaults.get(provider, "gpt-4-turbo-preview"))
+
+    def get_api_key(self, provider: str) -> str | None:
+        env_vars = {
+            "openai": "OPENAI_API_KEY",
+            "anthropic": "ANTHROPIC_API_KEY",
+            "google": "GOOGLE_API_KEY",
+        }
+        return os.getenv(env_vars.get(provider, ""))
+
+    def should_stream(self) -> bool:
+        return os.getenv("YAC_STREAM", "true").lower() == "true"
+
+    def _load_config(self) -> Dict:
+        if self.config_file.exists():
+            try:
+                with open(self.config_file, "r") as f:
+                    return json.load(f)
+            except (json.JSONDecodeError, IOError):
+                pass
+        return {"mcp_servers": {}}
+
+    def _save_config(self):
+        with open(self.config_file, "w") as f:
+            json.dump(self._config_data, f, indent=2)
+
+    def get_mcp_servers(self) -> Dict[str, MCPServerConfig]:
+        servers = {}
+        for name, data in self._config_data.get("mcp_servers", {}).items():
+            try:
+                servers[name] = MCPServerConfig(
+                    name=name,
+                    transport=MCPTransport(data["transport"]),
+                    command=data.get("command"),
+                    url=data.get("url"),
+                    env=data.get("env"),
+                    headers=data.get("headers"),
+                    args=data.get("args"),
+                )
+            except (KeyError, ValueError) as e:
+                print(f"Invalid MCP server config for {name}: {e}")
+        return servers
+
+    def add_mcp_server(self, config: MCPServerConfig):
+        self._config_data.setdefault("mcp_servers", {})[config.name] = {
+            "transport": config.transport.value,
+            "command": config.command,
+            "url": config.url,
+            "env": config.env,
+            "headers": config.headers,
+            "args": config.args,
+        }
+        self._save_config()
+
+    def remove_mcp_server(self, name: str) -> bool:
+        if name in self._config_data.get("mcp_servers", {}):
+            del self._config_data["mcp_servers"][name]
+            self._save_config()
+            return True
+        return False
+
+    def list_mcp_servers(self) -> List[str]:
+        return list(self._config_data.get("mcp_servers", {}).keys())
+
+    def validate_configuration(self, workspace_path: Optional[str] = None) -> str:
+        """Validate the current configuration and return a report."""
+        all_issues = []
+
+        # Validate provider/model/API key
+        provider = self.get_provider()
+        model = self.get_model()
+        api_key = self.get_api_key(provider)
+
+        provider_issues = self.validator.validate_provider_config(
+            provider, model, api_key
+        )
+        all_issues.extend(provider_issues)
+
+        # Validate MCP servers
+        for name, server_data in self._config_data.get("mcp_servers", {}).items():
+            server_issues = self.validator.validate_mcp_server_config(server_data)
+            # Add server name context to issues
+            for issue in server_issues:
+                if issue.field:
+                    issue.field = f"{name}.{issue.field}"
+                else:
+                    issue.field = name
+            all_issues.extend(server_issues)
+
+        # Validate environment
+        env_issues = self.validator.validate_environment()
+        all_issues.extend(env_issues)
+
+        # Validate workspace if provided
+        if workspace_path:
+            workspace_issues = self.validator.validate_workspace(workspace_path)
+            all_issues.extend(workspace_issues)
+
+        # Generate report
+        summary = self.reporter.get_summary(all_issues)
+        details = self.reporter.format_issues(all_issues)
+
+        return f"{summary}\n\n{details}" if all_issues else summary
+
+    def has_validation_errors(self, workspace_path: Optional[str] = None) -> bool:
+        """Check if configuration has any error-level validation issues."""
+        # Quick validation without generating full report
+        all_issues = []
+
+        provider = self.get_provider()
+        model = self.get_model()
+        api_key = self.get_api_key(provider)
+
+        all_issues.extend(
+            self.validator.validate_provider_config(provider, model, api_key)
+        )
+
+        for server_data in self._config_data.get("mcp_servers", {}).values():
+            all_issues.extend(self.validator.validate_mcp_server_config(server_data))
+
+        all_issues.extend(self.validator.validate_environment())
+
+        if workspace_path:
+            all_issues.extend(self.validator.validate_workspace(workspace_path))
+
+        return self.reporter.has_errors(all_issues)

--- a/src/yac/cli/display.py
+++ b/src/yac/cli/display.py
@@ -1,0 +1,46 @@
+import sys
+
+
+class Display:
+    def __init__(self):
+        self.use_colors = sys.stdout.isatty()
+
+    def _color(self, text: str, code: str) -> str:
+        if not self.use_colors:
+            return text
+        return f"\033[{code}m{text}\033[0m"
+
+    def print(self, text: str = ""):
+        print(text)
+
+    def error(self, text: str):
+        print(self._color(f"Error: {text}", "91"))
+
+    def welcome(self):
+        print(self._color("YAC (Yet Another Claude)", "1"))
+        print("Type /help for commands, /exit to quit")
+        print()
+
+    def goodbye(self):
+        print(self._color("Goodbye!", "1"))
+
+    def get_prompt(self) -> str:
+        return self._color("You: ", "94")
+
+    def print_response(self, content: str):
+        print(self._color("Assistant: ", "92") + content)
+        print()
+
+    def show_help(self):
+        print("""Available commands:
+  /help   - Show this help
+  /exit   - Exit the application
+  /clear  - Clear conversation history""")
+
+    def show_loading(self, message: str = "Processing..."):
+        """Show a loading indicator."""
+        print(self._color(f"⏳ {message}", "93"), end="", flush=True)
+
+    def clear_loading(self):
+        """Clear the loading line."""
+        print("\r" + " " * 50 + "\r", end="", flush=True)

--- a/src/yac/cli/error_handlers.py
+++ b/src/yac/cli/error_handlers.py
@@ -1,0 +1,294 @@
+"""Error handling strategies for different types of failures."""
+
+import asyncio
+from abc import ABC, abstractmethod
+from typing import Optional, List, Dict, Any
+
+
+class ErrorHandler(ABC):
+    """Abstract base class for error handling strategies."""
+
+    @abstractmethod
+    async def can_handle(self, error: Exception, context: Dict[str, Any]) -> bool:
+        """Check if this handler can handle the given error."""
+        pass
+
+    @abstractmethod
+    async def handle(self, error: Exception, context: Dict[str, Any]) -> Optional[str]:
+        """Handle the error and return recovery information or None."""
+        pass
+
+
+class FileNotFoundHandler(ErrorHandler):
+    """Handle file not found errors with intelligent suggestions."""
+
+    async def can_handle(self, error: Exception, context: Dict[str, Any]) -> bool:
+        error_str = str(error).lower()
+        return any(
+            phrase in error_str
+            for phrase in [
+                "file not found",
+                "no such file",
+                "does not exist",
+                "cannot find",
+            ]
+        )
+
+    async def handle(self, error: Exception, context: Dict[str, Any]) -> Optional[str]:
+        args = context.get("args", {})
+        tools = context.get("tools", [])
+
+        # Extract filename from args
+        filename = self._extract_filename(args)
+        if not filename:
+            return None
+
+        # Build contextual error message with investigation suggestions
+        error_context = f"File '{filename}' not found. "
+
+        # Suggest available investigation tools
+        available_tools = [t.name for t in tools]
+        investigation_tools = [
+            tool
+            for tool in available_tools
+            if tool
+            in ["search_files", "list_directory", "directory_tree", "execute_command"]
+        ]
+
+        if investigation_tools:
+            error_context += (
+                f"Available tools to investigate: {', '.join(investigation_tools)}. "
+            )
+            error_context += self._get_investigation_suggestions(filename)
+
+        return error_context
+
+    def _extract_filename(self, args: Any) -> Optional[str]:
+        """Extract filename from various argument formats."""
+        if isinstance(args, dict):
+            return args.get("path") or args.get("file_path") or args.get("filename")
+        elif isinstance(args, str):
+            return args
+        return None
+
+    def _get_investigation_suggestions(self, filename: str) -> str:
+        """Get specific investigation suggestions based on filename."""
+        import os
+
+        basename = os.path.basename(filename)
+        extension = os.path.splitext(basename)[1]
+
+        suggestions = [
+            f"search_files to look for '{basename}' or similar files",
+            "list_directory to see what's available in the current or parent directories",
+        ]
+
+        if extension:
+            suggestions.append(f"search for other {extension} files")
+
+        suggestions.append("execute_command with 'find' to search the filesystem")
+
+        return f"Consider using: {'; '.join(suggestions)}."
+
+
+class PermissionErrorHandler(ErrorHandler):
+    """Handle permission denied errors."""
+
+    async def can_handle(self, error: Exception, context: Dict[str, Any]) -> bool:
+        error_str = str(error).lower()
+        return any(
+            phrase in error_str
+            for phrase in [
+                "permission denied",
+                "access denied",
+                "not permitted",
+                "insufficient privileges",
+            ]
+        )
+
+    async def handle(self, error: Exception, context: Dict[str, Any]) -> Optional[str]:
+        tool_name = context.get("tool_name", "")
+
+        suggestions = [
+            "Check file/directory permissions",
+            "Verify you have the necessary access rights",
+            "Consider using sudo if appropriate",
+            "Check if the file is locked by another process",
+        ]
+
+        if "write" in tool_name.lower() or "edit" in tool_name.lower():
+            suggestions.append("Ensure the target location is writable")
+
+        return f"Permission denied. Suggestions: {'; '.join(suggestions)}."
+
+
+class NetworkErrorHandler(ErrorHandler):
+    """Handle network-related errors with retry logic."""
+
+    def __init__(self, max_retries: int = 2, retry_delay: float = 1.0):
+        self.max_retries = max_retries
+        self.retry_delay = retry_delay
+
+    async def can_handle(self, error: Exception, context: Dict[str, Any]) -> bool:
+        error_str = str(error).lower()
+        return any(
+            phrase in error_str
+            for phrase in [
+                "connection",
+                "timeout",
+                "network",
+                "unreachable",
+                "dns",
+                "socket",
+            ]
+        )
+
+    async def handle(self, error: Exception, context: Dict[str, Any]) -> Optional[str]:
+        tool_name = context.get("tool_name", "")
+        args = context.get("args", {})
+        tools = context.get("tools", [])
+
+        # Attempt retry for network operations
+        for attempt in range(self.max_retries):
+            try:
+                await asyncio.sleep(self.retry_delay * (attempt + 1))
+
+                # Find and retry the original tool
+                original_tool = next((t for t in tools if t.name == tool_name), None)
+                if original_tool:
+                    retry_result = await original_tool.ainvoke(args)
+                    return f"Network retry successful after {attempt + 1} attempts: {retry_result}"
+
+            except Exception as retry_error:
+                if attempt == self.max_retries - 1:
+                    return f"Network error persisted after {self.max_retries} retries. Last error: {retry_error}"
+
+        return "Network error occurred. Please check your connection and try again."
+
+
+class DirectoryNotFoundHandler(ErrorHandler):
+    """Handle directory not found errors."""
+
+    async def can_handle(self, error: Exception, context: Dict[str, Any]) -> bool:
+        error_str = str(error).lower()
+        return any(
+            phrase in error_str
+            for phrase in [
+                "directory not found",
+                "no such directory",
+                "path does not exist",
+            ]
+        )
+
+    async def handle(self, error: Exception, context: Dict[str, Any]) -> Optional[str]:
+        args = context.get("args", {})
+
+        directory = None
+        if isinstance(args, dict):
+            directory = args.get("path") or args.get("directory")
+        elif isinstance(args, str):
+            directory = args
+
+        if directory:
+            # Suggest checking parent directories
+            import os
+
+            parent_dir = os.path.dirname(directory)
+            suggestions = [
+                f"Check if parent directory '{parent_dir}' exists",
+                "Use list_directory to explore available paths",
+                "Consider creating the directory first if needed",
+                "Verify the path format is correct",
+            ]
+
+            return f"Directory '{directory}' not found. {'; '.join(suggestions)}."
+
+        return "Directory not found. Please verify the path exists."
+
+
+class ProcessErrorHandler(ErrorHandler):
+    """Handle process execution errors."""
+
+    async def can_handle(self, error: Exception, context: Dict[str, Any]) -> bool:
+        error_str = str(error).lower()
+        return any(
+            phrase in error_str
+            for phrase in [
+                "command not found",
+                "no such command",
+                "executable not found",
+                "process failed",
+                "exit code",
+            ]
+        )
+
+    async def handle(self, error: Exception, context: Dict[str, Any]) -> Optional[str]:
+        tool_name = context.get("tool_name", "")
+        args = context.get("args", {})
+
+        if "command not found" in str(error).lower():
+            command = args.get("command", "") if isinstance(args, dict) else str(args)
+            return (
+                f"Command '{command}' not found. Check if it's installed and in PATH."
+            )
+
+        if "exit code" in str(error).lower():
+            return "Command executed but failed. Check command syntax and arguments."
+
+        return f"Process execution error in {tool_name}. Verify command and arguments."
+
+
+class ErrorHandlerRegistry:
+    """Registry for managing error handlers with fallback chain."""
+
+    def __init__(self):
+        self.handlers: List[ErrorHandler] = [
+            FileNotFoundHandler(),
+            PermissionErrorHandler(),
+            NetworkErrorHandler(),
+            DirectoryNotFoundHandler(),
+            ProcessErrorHandler(),
+        ]
+
+    def add_handler(self, handler: ErrorHandler):
+        """Add a custom error handler to the registry."""
+        self.handlers.insert(0, handler)  # Custom handlers get priority
+
+    async def handle_error(
+        self, error: Exception, tool_name: str, args: Any, tools: List[Any]
+    ) -> Optional[str]:
+        """Find appropriate handler and process the error."""
+        context = {
+            "tool_name": tool_name,
+            "args": args,
+            "tools": tools,
+            "error_type": type(error).__name__,
+        }
+
+        for handler in self.handlers:
+            try:
+                if await handler.can_handle(error, context):
+                    result = await handler.handle(error, context)
+                    if result:
+                        return result
+            except Exception as handler_error:
+                # Don't let handler errors break the chain
+                print(f"Error in handler {type(handler).__name__}: {handler_error}")
+                continue
+
+        # Fallback for unhandled errors
+        return f"Unhandled error in {tool_name}: {error}. Please check your input and try again."
+
+
+class GracefulErrorMixin:
+    """Mixin to add graceful error handling to any class."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.error_registry = ErrorHandlerRegistry()
+
+    async def handle_tool_error_gracefully(
+        self, error: Exception, tool_name: str, args: Any, tools: List[Any]
+    ) -> str:
+        """Handle tool errors with the error registry."""
+        return await self.error_registry.handle_error(error, tool_name, args, tools)

--- a/src/yac/cli/validators.py
+++ b/src/yac/cli/validators.py
@@ -1,0 +1,375 @@
+"""Configuration validators for YAC (Yet Another Claude)."""
+
+import os
+import re
+from typing import List, Dict, Any, Optional
+from dataclasses import dataclass
+from enum import Enum
+
+
+class ValidationSeverity(Enum):
+    """Severity levels for validation issues."""
+
+    ERROR = "error"
+    WARNING = "warning"
+    INFO = "info"
+
+
+@dataclass
+class ValidationIssue:
+    """Represents a configuration validation issue."""
+
+    severity: ValidationSeverity
+    message: str
+    field: Optional[str] = None
+    suggestion: Optional[str] = None
+
+
+class ConfigValidator:
+    """Validates configuration settings for YAC."""
+
+    # Known valid models for each provider
+    VALID_MODELS = {
+        "openai": [
+            "gpt-4o",
+            "gpt-4o-mini",
+            "gpt-4-turbo",
+            "gpt-4-turbo-preview",
+            "gpt-4",
+            "gpt-3.5-turbo",
+            "o1-preview",
+            "o1-mini",
+            "o3-mini",
+        ],
+        "anthropic": [
+            "claude-3-5-sonnet-20241022",
+            "claude-3-5-haiku-20241022",
+            "claude-3-opus-20240229",
+            "claude-3-sonnet-20240229",
+            "claude-3-haiku-20240307",
+        ],
+        "google": [
+            "gemini-1.5-pro",
+            "gemini-1.5-flash",
+            "gemini-1.0-pro",
+            "gemini-pro",
+            "gemini-pro-vision",
+        ],
+    }
+
+    # Required environment variables for each provider
+    REQUIRED_ENV_VARS = {
+        "openai": "OPENAI_API_KEY",
+        "anthropic": "ANTHROPIC_API_KEY",
+        "google": "GOOGLE_API_KEY",
+    }
+
+    def __init__(self):
+        self.issues: List[ValidationIssue] = []
+
+    def validate_provider_config(
+        self, provider: str, model: str, api_key: Optional[str] = None
+    ) -> List[ValidationIssue]:
+        """Validate AI provider configuration."""
+        self.issues = []
+
+        # Validate provider
+        if provider not in self.VALID_MODELS:
+            self.issues.append(
+                ValidationIssue(
+                    severity=ValidationSeverity.ERROR,
+                    message=f"Unknown provider '{provider}'",
+                    field="provider",
+                    suggestion=f"Valid providers: {', '.join(self.VALID_MODELS.keys())}",
+                )
+            )
+            return self.issues
+
+        # Validate model for provider
+        valid_models = self.VALID_MODELS[provider]
+        if model not in valid_models:
+            self.issues.append(
+                ValidationIssue(
+                    severity=ValidationSeverity.WARNING,
+                    message=f"Model '{model}' not in known models for {provider}",
+                    field="model",
+                    suggestion=f"Common models for {provider}: {', '.join(valid_models[:3])}",
+                )
+            )
+
+        # Validate API key
+        env_var = self.REQUIRED_ENV_VARS[provider]
+        actual_api_key = api_key or os.getenv(env_var)
+
+        if not actual_api_key:
+            self.issues.append(
+                ValidationIssue(
+                    severity=ValidationSeverity.ERROR,
+                    message=f"Missing API key for {provider}",
+                    field="api_key",
+                    suggestion=f"Set {env_var} environment variable",
+                )
+            )
+        elif len(actual_api_key) < 10:
+            self.issues.append(
+                ValidationIssue(
+                    severity=ValidationSeverity.WARNING,
+                    message=f"API key for {provider} seems too short",
+                    field="api_key",
+                    suggestion="Verify the API key is complete",
+                )
+            )
+
+        return self.issues
+
+    def validate_mcp_server_config(
+        self, server_config: Dict[str, Any]
+    ) -> List[ValidationIssue]:
+        """Validate MCP server configuration."""
+        self.issues = []
+
+        # Required fields
+        required_fields = ["name", "transport", "command"]
+        for field in required_fields:
+            if field not in server_config:
+                self.issues.append(
+                    ValidationIssue(
+                        severity=ValidationSeverity.ERROR,
+                        message=f"Missing required field '{field}' in MCP server config",
+                        field=field,
+                    )
+                )
+
+        # Validate transport
+        valid_transports = ["stdio", "sse", "http"]
+        transport = server_config.get("transport", "").lower()
+        if transport not in valid_transports:
+            self.issues.append(
+                ValidationIssue(
+                    severity=ValidationSeverity.ERROR,
+                    message=f"Invalid transport '{transport}'",
+                    field="transport",
+                    suggestion=f"Valid transports: {', '.join(valid_transports)}",
+                )
+            )
+
+        # Validate command for stdio transport
+        if transport == "stdio":
+            command = server_config.get("command", [])
+            if not command or not isinstance(command, list) or len(command) == 0:
+                self.issues.append(
+                    ValidationIssue(
+                        severity=ValidationSeverity.ERROR,
+                        message="STDIO transport requires a valid command array",
+                        field="command",
+                    )
+                )
+            elif command[0] in ["npx", "npm"]:
+                # Check if Node.js is available
+                if not self._check_command_available("node"):
+                    self.issues.append(
+                        ValidationIssue(
+                            severity=ValidationSeverity.WARNING,
+                            message="Node.js not found but required for npx/npm commands",
+                            suggestion="Install Node.js to use this MCP server",
+                        )
+                    )
+
+        # Validate URL for HTTP/SSE transports
+        if transport in ["http", "sse"]:
+            url = server_config.get("url")
+            if not url:
+                self.issues.append(
+                    ValidationIssue(
+                        severity=ValidationSeverity.ERROR,
+                        message=f"{transport.upper()} transport requires a URL",
+                        field="url",
+                    )
+                )
+            elif not self._is_valid_url(url):
+                self.issues.append(
+                    ValidationIssue(
+                        severity=ValidationSeverity.WARNING,
+                        message=f"URL '{url}' may not be valid",
+                        field="url",
+                    )
+                )
+
+        return self.issues
+
+    def validate_environment(self) -> List[ValidationIssue]:
+        """Validate the runtime environment."""
+        self.issues = []
+
+        # Check Python version
+        import sys
+
+        python_version = sys.version_info
+        if python_version < (3, 8):
+            self.issues.append(
+                ValidationIssue(
+                    severity=ValidationSeverity.ERROR,
+                    message=f"Python {python_version.major}.{python_version.minor} is too old",
+                    suggestion="Python 3.8+ is required",
+                )
+            )
+
+        # Check for essential commands
+        essential_commands = ["git"]
+        for cmd in essential_commands:
+            if not self._check_command_available(cmd):
+                self.issues.append(
+                    ValidationIssue(
+                        severity=ValidationSeverity.WARNING,
+                        message=f"Command '{cmd}' not found in PATH",
+                        suggestion=f"Install {cmd} for full functionality",
+                    )
+                )
+
+        # Check disk space (basic check)
+        try:
+            import shutil
+
+            free_space = shutil.disk_usage(".").free / (1024**3)  # GB
+            if free_space < 1.0:
+                self.issues.append(
+                    ValidationIssue(
+                        severity=ValidationSeverity.WARNING,
+                        message=f"Low disk space: {free_space:.1f}GB available",
+                        suggestion="Consider freeing up disk space",
+                    )
+                )
+        except Exception:
+            pass  # Skip if can't check disk space
+
+        return self.issues
+
+    def validate_workspace(self, workspace_path: str) -> List[ValidationIssue]:
+        """Validate workspace directory."""
+        self.issues = []
+
+        if not os.path.exists(workspace_path):
+            self.issues.append(
+                ValidationIssue(
+                    severity=ValidationSeverity.ERROR,
+                    message=f"Workspace path does not exist: {workspace_path}",
+                    field="workspace_path",
+                    suggestion="Create the directory or use a valid path",
+                )
+            )
+            return self.issues
+
+        if not os.path.isdir(workspace_path):
+            self.issues.append(
+                ValidationIssue(
+                    severity=ValidationSeverity.ERROR,
+                    message=f"Workspace path is not a directory: {workspace_path}",
+                    field="workspace_path",
+                )
+            )
+            return self.issues
+
+        # Check permissions
+        if not os.access(workspace_path, os.R_OK):
+            self.issues.append(
+                ValidationIssue(
+                    severity=ValidationSeverity.ERROR,
+                    message=f"No read permission for workspace: {workspace_path}",
+                    field="workspace_path",
+                )
+            )
+
+        if not os.access(workspace_path, os.W_OK):
+            self.issues.append(
+                ValidationIssue(
+                    severity=ValidationSeverity.WARNING,
+                    message=f"No write permission for workspace: {workspace_path}",
+                    field="workspace_path",
+                    suggestion="Some operations may fail without write access",
+                )
+            )
+
+        # Check if it's a git repository
+        git_dir = os.path.join(workspace_path, ".git")
+        if os.path.exists(git_dir):
+            self.issues.append(
+                ValidationIssue(
+                    severity=ValidationSeverity.INFO,
+                    message="Workspace is a Git repository - Git tools will be available",
+                )
+            )
+
+        return self.issues
+
+    def _check_command_available(self, command: str) -> bool:
+        """Check if a command is available in PATH."""
+        import shutil
+
+        return shutil.which(command) is not None
+
+    def _is_valid_url(self, url: str) -> bool:
+        """Basic URL validation."""
+        url_pattern = re.compile(
+            r"^https?://"  # http:// or https://
+            r"(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+[A-Z]{2,6}\.?|"  # domain...
+            r"localhost|"  # localhost...
+            r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})"  # ...or ip
+            r"(?::\d+)?"  # optional port
+            r"(?:/?|[/?]\S+)$",
+            re.IGNORECASE,
+        )
+        return url_pattern.match(url) is not None
+
+
+class ValidationReporter:
+    """Formats and reports validation results."""
+
+    def __init__(self):
+        self.severity_colors = {
+            ValidationSeverity.ERROR: "🔴",
+            ValidationSeverity.WARNING: "🟡",
+            ValidationSeverity.INFO: "🔵",
+        }
+
+    def format_issues(self, issues: List[ValidationIssue]) -> str:
+        """Format validation issues for display."""
+        if not issues:
+            return "✅ No issues found"
+
+        lines = []
+        for issue in issues:
+            icon = self.severity_colors[issue.severity]
+            field_info = f" ({issue.field})" if issue.field else ""
+            line = f"{icon} {issue.severity.value.upper()}{field_info}: {issue.message}"
+
+            if issue.suggestion:
+                line += f"\n   💡 Suggestion: {issue.suggestion}"
+
+            lines.append(line)
+
+        return "\n".join(lines)
+
+    def get_summary(self, issues: List[ValidationIssue]) -> str:
+        """Get a summary of validation results."""
+        if not issues:
+            return "✅ Configuration validation passed"
+
+        error_count = sum(1 for i in issues if i.severity == ValidationSeverity.ERROR)
+        warning_count = sum(
+            1 for i in issues if i.severity == ValidationSeverity.WARNING
+        )
+        info_count = sum(1 for i in issues if i.severity == ValidationSeverity.INFO)
+
+        parts = []
+        if error_count:
+            parts.append(f"{error_count} error(s)")
+        if warning_count:
+            parts.append(f"{warning_count} warning(s)")
+        if info_count:
+            parts.append(f"{info_count} info")
+
+        return f"🔍 Validation complete: {', '.join(parts)}"
+
+    def has_errors(self, issues: List[ValidationIssue]) -> bool:
+        """Check if there are any error-level issues."""
+        return any(issue.severity == ValidationSeverity.ERROR for issue in issues)

--- a/src/yac/main.py
+++ b/src/yac/main.py
@@ -1,0 +1,4 @@
+from .cli.app import main
+
+if __name__ == "__main__":
+    main()

--- a/src/yac/mcp/__init__.py
+++ b/src/yac/mcp/__init__.py
@@ -1,0 +1,1 @@
+"""MCP (Model Context Protocol) integration for YAC."""

--- a/src/yac/mcp/client.py
+++ b/src/yac/mcp/client.py
@@ -1,0 +1,94 @@
+"""MCP Client for managing connections to MCP servers."""
+
+import asyncio
+import json
+import logging
+from typing import Dict, List, Optional, Any
+from .config import MCPServerConfig, MCPTransport
+from .simple_session import SimpleSession
+
+logger = logging.getLogger(__name__)
+
+
+class MCPClient:
+    """Client for managing MCP server connections."""
+
+    def __init__(self):
+        self.sessions: Dict[str, SimpleSession] = {}
+        self.tools_cache: Dict[str, List[Dict[str, Any]]] = {}
+
+    async def add_server(self, config: MCPServerConfig) -> bool:
+        """Add and connect to an MCP server."""
+        try:
+            session = SimpleSession()
+            success = await session.connect(config)
+            
+            if success:
+                self.sessions[config.name] = session
+                # Cache tools for this server
+                await self._cache_server_tools(config.name)
+                return True
+            return False
+        except Exception as e:
+            logger.error(f"Failed to add MCP server {config.name}: {e}")
+            return False
+
+    async def remove_server(self, name: str) -> bool:
+        """Remove and disconnect from an MCP server."""
+        if name in self.sessions:
+            try:
+                await self.sessions[name].close()
+                del self.sessions[name]
+                if name in self.tools_cache:
+                    del self.tools_cache[name]
+                return True
+            except Exception as e:
+                logger.error(f"Failed to remove MCP server {name}: {e}")
+        return False
+
+    async def call_tool(self, server_name: str, tool_name: str, arguments: Dict[str, Any]) -> Any:
+        """Call a tool on a specific server."""
+        if server_name not in self.sessions:
+            raise ValueError(f"Server {server_name} not connected")
+        
+        session = self.sessions[server_name]
+        return await session.call_tool(tool_name, arguments)
+
+    async def list_tools(self, server_name: Optional[str] = None) -> Dict[str, List[Dict[str, Any]]]:
+        """List available tools from servers."""
+        if server_name:
+            if server_name in self.tools_cache:
+                return {server_name: self.tools_cache[server_name]}
+            return {}
+        
+        return self.tools_cache.copy()
+
+    async def get_all_tools(self) -> List[Dict[str, Any]]:
+        """Get all tools from all connected servers."""
+        all_tools = []
+        for server_name, tools in self.tools_cache.items():
+            for tool in tools:
+                tool_with_server = tool.copy()
+                tool_with_server['server_name'] = server_name
+                all_tools.append(tool_with_server)
+        return all_tools
+
+    async def _cache_server_tools(self, server_name: str):
+        """Cache tools for a specific server."""
+        try:
+            session = self.sessions[server_name]
+            tools = await session.list_tools()
+            self.tools_cache[server_name] = tools
+        except Exception as e:
+            logger.error(f"Failed to cache tools for {server_name}: {e}")
+            self.tools_cache[server_name] = []
+
+    async def close_all(self):
+        """Close all server connections."""
+        for session in self.sessions.values():
+            try:
+                await session.close()
+            except Exception as e:
+                logger.error(f"Error closing session: {e}")
+        self.sessions.clear()
+        self.tools_cache.clear()

--- a/src/yac/mcp/config.py
+++ b/src/yac/mcp/config.py
@@ -1,0 +1,40 @@
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Union
+from enum import Enum
+
+
+class MCPTransport(Enum):
+    STDIO = "stdio"
+    SSE = "sse"
+    HTTP = "http"
+
+
+@dataclass
+class MCPServerConfig:
+    name: str
+    transport: MCPTransport
+    command: Optional[List[str]] = None
+    url: Optional[str] = None
+    env: Optional[Dict[str, str]] = None
+    headers: Optional[Dict[str, str]] = None
+    args: Optional[List[str]] = None
+
+    def __post_init__(self):
+        if self.transport == MCPTransport.STDIO and not self.command:
+            raise ValueError("STDIO transport requires command")
+        if self.transport in [MCPTransport.SSE, MCPTransport.HTTP] and not self.url:
+            raise ValueError(f"{self.transport.value} transport requires url")
+
+
+@dataclass
+class MCPToolCall:
+    name: str
+    arguments: Dict[str, Union[str, int, float, bool, None]]
+    server_name: str
+
+
+@dataclass
+class MCPToolResult:
+    content: str
+    is_error: bool = False
+    metadata: Optional[Dict[str, str]] = None

--- a/src/yac/mcp/defaults.py
+++ b/src/yac/mcp/defaults.py
@@ -1,0 +1,240 @@
+import os
+from pathlib import Path
+from typing import Dict, List
+from .config import MCPServerConfig, MCPTransport
+
+
+def get_default_mcp_servers(
+    workspace_path: str | None = None,
+) -> Dict[str, MCPServerConfig]:
+    """Get default MCP server configurations for YAC compatibility."""
+
+    if workspace_path is None:
+        workspace_path = str(Path.cwd())
+
+    servers = {
+        "filesystem": MCPServerConfig(
+            name="filesystem",
+            transport=MCPTransport.STDIO,
+            command=[
+                "npx",
+                "-y",
+                "@modelcontextprotocol/server-filesystem",
+                workspace_path,
+            ],
+        ),
+        "fetch": MCPServerConfig(
+            name="fetch",
+            transport=MCPTransport.STDIO,
+            command=[
+                "npx",
+                "-y",
+                "@kazuph/mcp-fetch",
+            ],
+        ),
+        "git": MCPServerConfig(
+            name="git",
+            transport=MCPTransport.STDIO,
+            command=[
+                "npx",
+                "-y",
+                "@cyanheads/git-mcp-server",
+            ],
+        ),
+        "bash": MCPServerConfig(
+            name="bash",
+            transport=MCPTransport.STDIO,
+            command=[
+                "npx",
+                "-y",
+                "@wonderwhy-er/desktop-commander",
+            ],
+        ),
+    }
+
+    # Add Brave Search if API key is available
+    brave_api_key = os.getenv("BRAVE_API_KEY")
+    if brave_api_key:
+        servers["brave-search"] = MCPServerConfig(
+            name="brave-search",
+            transport=MCPTransport.STDIO,
+            command=[
+                "npx",
+                "-y",
+                "@modelcontextprotocol/server-brave-search",
+            ],
+            env={"BRAVE_API_KEY": brave_api_key},
+        )
+
+    # Add Puppeteer (no API key required, but might need Chrome installed)
+    servers["puppeteer"] = MCPServerConfig(
+        name="puppeteer",
+        transport=MCPTransport.STDIO,
+        command=[
+            "npx",
+            "-y",
+            "@modelcontextprotocol/server-puppeteer",
+        ],
+    )
+
+    # Sequential Thinking MCP (moved from optional for enhanced reasoning)
+    servers["sequential-thinking"] = MCPServerConfig(
+        name="sequential-thinking",
+        transport=MCPTransport.STDIO,
+        command=[
+            "npx",
+            "-y",
+            "@modelcontextprotocol/server-sequential-thinking",
+        ],
+    )
+
+    return servers
+
+
+def get_essential_tools() -> List[str]:
+    """List of essential tools that should be available."""
+    return [
+        # Filesystem operations
+        "read_file",
+        "write_file",
+        "edit_file",
+        "list_directory",
+        "create_directory",
+        "search_files",
+        "move_file",
+        "get_file_info",
+        "directory_tree",
+        "read_multiple_files",
+        # Git operations (always available)
+        "git_status",
+        "git_diff",
+        "git_log",
+        "git_add",
+        "git_commit",
+        "git_push",
+        "git_pull",
+        "git_branch",
+        "git_checkout",
+        "git_clone",
+        # Terminal/bash operations (always available)
+        "execute_command",
+        "run_bash",
+        "list_processes",
+        "get_directory",
+        "change_directory",
+        # Web browsing and search
+        "brave_search",
+        "fetch_url",
+        "puppeteer_navigate",
+        "puppeteer_screenshot",
+        "puppeteer_click",
+        "puppeteer_type",
+        # GitHub operations (if available)
+        "get_repo",
+        "list_repos",
+        "create_issue",
+        "get_issue",
+        "create_pull_request",
+        # Memory operations (if available)
+        "store_memory",
+        "retrieve_memory",
+        "search_memory",
+        # Code execution (if available)
+        "execute_python",
+        "run_code",
+        "execute_script",
+    ]
+
+
+def get_optional_mcp_servers(
+    workspace_path: str | None = None,
+) -> Dict[str, MCPServerConfig]:
+    """Get optional MCP server configurations that require additional setup or API keys."""
+
+    if workspace_path is None:
+        workspace_path = str(Path.cwd())
+
+    servers = {}
+
+    # GitHub MCP server (requires GitHub token)
+    github_token = os.getenv("GITHUB_TOKEN")
+    if github_token:
+        servers["github"] = MCPServerConfig(
+            name="github",
+            transport=MCPTransport.STDIO,
+            command=[
+                "npx",
+                "-y",
+                "@modelcontextprotocol/server-github",
+            ],
+            env={"GITHUB_TOKEN": github_token},
+        )
+
+    # Slack MCP server (requires Slack bot token)
+    slack_bot_token = os.getenv("SLACK_BOT_TOKEN")
+    if slack_bot_token:
+        servers["slack"] = MCPServerConfig(
+            name="slack",
+            transport=MCPTransport.STDIO,
+            command=[
+                "npx",
+                "-y",
+                "@modelcontextprotocol/server-slack",
+            ],
+            env={"SLACK_BOT_TOKEN": slack_bot_token},
+        )
+
+    # SQLite MCP server for database operations
+    servers["sqlite"] = MCPServerConfig(
+        name="sqlite",
+        transport=MCPTransport.STDIO,
+        command=[
+            "npx",
+            "-y",
+            "@modelcontextprotocol/server-sqlite",
+        ],
+    )
+
+    # Memory MCP server (requires configuration)
+    servers["memory"] = MCPServerConfig(
+        name="memory",
+        transport=MCPTransport.STDIO,
+        command=[
+            "npx",
+            "-y",
+            "@modelcontextprotocol/server-memory",
+        ],
+    )
+
+    # Desktop Commander MCP - provides terminal control and file editing
+    servers["desktop-commander"] = MCPServerConfig(
+        name="desktop-commander",
+        transport=MCPTransport.STDIO,
+        command=[
+            "npx",
+            "-y",
+            "@wonderwhy-er/desktop-commander",
+        ],
+    )
+
+    # Code execution server for Python
+    servers["code-executor"] = MCPServerConfig(
+        name="code-executor",
+        transport=MCPTransport.STDIO,
+        command=[
+            "npx",
+            "-y",
+            "@modelcontextprotocol/server-code-executor",
+        ],
+    )
+
+    return servers
+
+
+def get_all_mcp_servers(
+    workspace_path: str | None = None,
+) -> Dict[str, MCPServerConfig]:
+    """Get all available MCP servers (default + optional)."""
+    servers = get_default_mcp_servers(workspace_path)
+    servers.update(get_optional_mcp_servers(workspace_path))
+    return servers

--- a/src/yac/mcp/langchain_bridge.py
+++ b/src/yac/mcp/langchain_bridge.py
@@ -1,0 +1,64 @@
+"""Bridge between MCP tools and LangChain tools."""
+
+from typing import Any, Dict, List, Optional
+from langchain_core.tools import StructuredTool
+from pydantic import Field, create_model
+from .client import MCPClient
+
+
+def create_mcp_tool_function(tool_name: str, server_name: str, mcp_client: MCPClient):
+    """Create an async function that executes an MCP tool."""
+
+    async def mcp_tool_func(**kwargs: Any) -> str:
+        try:
+            # Execute the tool
+            result = await mcp_client.call_tool(server_name, tool_name, kwargs)
+            return str(result)
+        except Exception as e:
+            return f"Error executing {tool_name}: {str(e)}"
+
+    return mcp_tool_func
+
+
+class MCPLangChainBridge:
+    """Bridge that converts MCP tools to LangChain tools."""
+
+    def __init__(self, mcp_client: MCPClient):
+        self.mcp_client = mcp_client
+
+    async def get_langchain_tools(
+        self, server_name: Optional[str] = None
+    ) -> List[StructuredTool]:
+        """Convert MCP tools to LangChain tools."""
+        tools = []
+
+        # Get tools from MCP servers
+        mcp_tools = await self.mcp_client.list_tools(server_name)
+
+        for server, server_tools in mcp_tools.items():
+            for tool_data in server_tools:
+                # Extract tool information
+                tool_name = tool_data.get("name", "unknown")
+                tool_description = tool_data.get(
+                    "description", "No description available"
+                )
+
+                # Create tool function
+                tool_func = create_mcp_tool_function(tool_name, server, self.mcp_client)
+
+                # Create LangChain tool
+                langchain_tool = StructuredTool(
+                    name=tool_name,
+                    description=tool_description,
+                    func=tool_func,
+                )
+                tools.append(langchain_tool)
+
+        return tools
+
+    async def bind_tools_to_llm(self, llm):
+        """Bind MCP tools to a LangChain LLM."""
+        tools = await self.get_langchain_tools()
+        if tools:
+            return llm.bind_tools(tools)
+        return llm

--- a/src/yac/mcp/simple_session.py
+++ b/src/yac/mcp/simple_session.py
@@ -1,0 +1,139 @@
+"""
+Simple MCP client session that works directly with subprocess stdio.
+This is a workaround for issues with the mcp library's stdio_client.
+"""
+
+import asyncio
+import json
+from typing import Dict, Any
+
+
+class SimpleClientSession:
+    """Simple MCP client session that communicates directly with a subprocess."""
+
+    def __init__(self, process):
+        self.process = process
+        self._request_id = 1
+
+    def _next_id(self):
+        self._request_id += 1
+        return self._request_id
+
+    async def _send_request(
+        self, method: str, params: Dict[str, Any] | None = None
+    ) -> Dict[str, Any]:
+        """Send a JSON-RPC request and return the response."""
+        request = {"jsonrpc": "2.0", "id": self._next_id(), "method": method}
+        if params:
+            request["params"] = params
+
+        # Send request
+        request_json = json.dumps(request) + "\n"
+        self.process.stdin.write(request_json.encode())
+        await self.process.stdin.drain()
+
+        # Read response - handle large responses by reading more data if needed
+        try:
+            response_line = await self.process.stdout.readline()
+            if not response_line:
+                raise Exception(f"No response from server for {method}")
+
+            response_text = response_line.decode().strip()
+            response = json.loads(response_text)
+
+        except json.JSONDecodeError:
+            # If JSON decode fails, it might be a truncated large response
+            # Try reading more data
+            additional_data = b""
+            try:
+                # Read up to 1MB more data for large responses
+                while len(additional_data) < 1024 * 1024:  # 1MB limit
+                    chunk = await asyncio.wait_for(
+                        self.process.stdout.read(8192), timeout=1.0
+                    )
+                    if not chunk:
+                        break
+                    additional_data += chunk
+
+                    # Try parsing the combined data
+                    combined_text = (response_line + additional_data).decode().strip()
+                    try:
+                        response = json.loads(combined_text)
+                        break
+                    except json.JSONDecodeError:
+                        continue
+                else:
+                    raise Exception(f"Response too large or malformed for {method}")
+
+            except asyncio.TimeoutError:
+                raise Exception(f"Response incomplete or server hung for {method}")
+            except Exception as read_error:
+                raise Exception(
+                    f"Failed to read large response for {method}: {read_error}"
+                )
+
+        if "error" in response:
+            raise Exception(f"Server error for {method}: {response['error']}")
+
+        return response
+
+    async def list_tools(self):
+        """List available tools from the MCP server."""
+        response = await self._send_request("tools/list")
+
+        # Convert to the format expected by the calling code
+        class ToolsResult:
+            def __init__(self, tools_data):
+                self.tools = []
+                if "result" in tools_data and "tools" in tools_data["result"]:
+                    for tool_data in tools_data["result"]["tools"]:
+                        self.tools.append(Tool(tool_data))
+
+        class Tool:
+            def __init__(self, data):
+                self.data = data
+
+            def model_dump(self):
+                return self.data
+
+        return ToolsResult(response)
+
+    async def call_tool(self, name: str, arguments: Dict[str, Any]):
+        """Call a tool on the MCP server."""
+        params = {"name": name, "arguments": arguments}
+        response = await self._send_request("tools/call", params)
+
+        # Convert to the format expected by the calling code
+        class ToolResult:
+            def __init__(self, result_data):
+                self.content = []
+                self.isError = False
+
+                if "result" in result_data:
+                    result = result_data["result"]
+                    if "content" in result:
+                        for item in result["content"]:
+                            self.content.append(ContentItem(item))
+                    if "isError" in result:
+                        self.isError = result["isError"]
+
+        class ContentItem:
+            def __init__(self, data):
+                self.text = data.get("text", "")
+                self.data = data
+
+        return ToolResult(response)
+
+    async def close(self):
+        """Close the session and terminate the process."""
+        if self.process:
+            self.process.terminate()
+            try:
+                await asyncio.wait_for(self.process.wait(), timeout=5.0)
+            except asyncio.TimeoutError:
+                self.process.kill()
+                await self.process.wait()
+
+
+# Compatibility alias for the old name
+SimpleSession = SimpleClientSession

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,5 +1,5 @@
 import os
-from yet_claude_code.cli.config import Config
+from yac.cli.config import Config
 
 
 def test_config_defaults():
@@ -10,9 +10,9 @@ def test_config_defaults():
 
 
 def test_config_env_vars():
-    os.environ["YCC_PROVIDER"] = "anthropic"
-    os.environ["YCC_MODEL"] = "claude-3-haiku-20240307"
-    os.environ["YCC_STREAM"] = "false"
+    os.environ["YAC_PROVIDER"] = "anthropic"
+    os.environ["YAC_MODEL"] = "claude-3-haiku-20240307"
+    os.environ["YAC_STREAM"] = "false"
 
     config = Config()
     assert config.get_provider() == "anthropic"
@@ -20,9 +20,9 @@ def test_config_env_vars():
     assert config.should_stream() is False
 
     # Clean up
-    del os.environ["YCC_PROVIDER"]
-    del os.environ["YCC_MODEL"]
-    del os.environ["YCC_STREAM"]
+    del os.environ["YAC_PROVIDER"]
+    del os.environ["YAC_MODEL"]
+    del os.environ["YAC_STREAM"]
 
 
 def test_api_key_retrieval():


### PR DESCRIPTION
Rename the application from "yet-claude-code" to "yac" (Yet Another Claude) throughout the codebase.

## Changes
- Create new `src/yac/` package directory with all modules
- Update `pyproject.toml`: name, description, scripts entry point
- Update CLI welcome message and app class name
- Update config directory from `~/.yet-claude-code` to `~/.yac`
- Update environment variables from `YCC_*` to `YAC_*`
- Update documentation and test files
- Maintain full compatibility with existing MCP integration

Closes #4

Generated with [Claude Code](https://claude.ai/code)